### PR TITLE
Remove 'main' attribute from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "bourbon",
   "description": "A simple and lightweight mixin library for Sass.",
   "version": "4.2.0",
-  "main": "app/assets/stylesheets/_bourbon.scss",
   "license": "MIT",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Grunt tasks like grunt-bower and grunt-bower-task only copy over that single file (_bourbon.scss).
_bourbon.scss however imports all other files and thus doesn't work.
It forces overrides to be written the aforementioned tasks.
This resolves that issue.
